### PR TITLE
feat: refactor date inputs to native Date Objects and replace react-tailwindcss-datepicker #8

### DIFF
--- a/resources/js/Shared/DataPickerInputEnd.jsx
+++ b/resources/js/Shared/DataPickerInputEnd.jsx
@@ -1,30 +1,32 @@
-import Datepicker from "react-tailwindcss-datepicker";
-import { useState, useEffect } from "react";
+import DatePicker from 'react-date-picker';
+import { useEffect, useState } from "react";
 
-export default function DataPickerInputEnd({ end, handleOnChange, className, placeholder }) {
-    const [value, setValue] = useState({
-        startDate: new Date(end).toLocaleDateString('pt-BR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/(\d+)\/(\d+)\/(\d+)/, '$3-$2-$1'),
-        endDate: new Date(end).toLocaleDateString('pt-BR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/(\d+)\/(\d+)\/(\d+)/, '$3-$2-$1'),
-    });
+export default function DataPickerInputEnd({ end, handleOnChange, className }) {
+    const [value, setValue] = useState(end ? new Date(end) : null);
 
-    const handleValueChange = (newValue) => {
-        setValue(newValue);
-    }
- 
+    const onChange = (date) => {
+        setValue(date);
+    };
+
     useEffect(() => {
-        handleOnChange({ target: { name: 'end', value: value.startDate } });
+        const formattedDate = value instanceof Date
+            ? value.toLocaleDateString('en-CA') 
+            : value;
+
+        handleOnChange({ target: { name: 'end', value: formattedDate } });
     }, [value]);
 
     return (
-        <Datepicker
-            i18n={"es_ES"}
-            placeholder={placeholder ?? "Seleccione la fecha de cierre del evento"}
-            value={value}
-            useRange={false}
-            asSingle={true}
-            onChange={handleValueChange}
-            containerClassName={className}
-            displayFormat={"DD/MM/YYYY"}
-        />
+        <div className={className}>
+            <DatePicker
+                onChange={onChange}
+                value={value}
+                locale="es-UY"
+                format="dd/MM/yyyy"
+                className="mt-1 block w-full text-stone-800 font-bold kimput"
+                calendarClassName="bg-white border rounded-lg shadow-lg"
+                clearIcon={null}
+            />
+        </div>
     );
 }

--- a/resources/js/Shared/DataPickerInputStart.jsx
+++ b/resources/js/Shared/DataPickerInputStart.jsx
@@ -1,33 +1,32 @@
-import Datepicker from "react-tailwindcss-datepicker";
-import { useState, useEffect } from "react";
+import DatePicker from 'react-date-picker';
+import { useEffect, useState } from "react";
 
-export default function DataPickerInputStart({ start, handleOnChange, className, placeholder }) {
-    const [value, setValue] = useState({
-        startDate: new Date(start).toLocaleDateString('pt-BR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/(\d+)\/(\d+)\/(\d+)/, '$3-$2-$1'),
-        endDate: new Date(start).toLocaleDateString('pt-BR', { year: 'numeric', month: '2-digit', day: '2-digit' }).replace(/(\d+)\/(\d+)\/(\d+)/, '$3-$2-$1'),
-    });
+export default function DataPickerInputStart({ start, handleOnChange, className }) {
+    const [value, setValue] = useState(start ? new Date(start) : null);
 
-    const handleValueChange = (newValue) => {
-        setValue(newValue);
-    }
+    const onChange = (date) => {
+        setValue(date);
+    };
 
     useEffect(() => {
-        if (value !== null && value.startDate !== null && value.startDate !== undefined && value.startDate !== '' && value.startDate !== 'Invalid Date') {
+        const formattedDate = value instanceof Date 
+            ? value.toLocaleDateString('en-CA')
+            : value;
 
-        }
-        handleOnChange({ target: { name: 'start', value: value.startDate } });
+        handleOnChange({ target: { name: 'start', value: formattedDate } });
     }, [value]);
 
     return (
-        <Datepicker
-            i18n={"es_ES"}
-            placeholder={placeholder ?? "Seleccione la fecha de inicio del evento"}
-            value={value}
-            useRange={false}
-            asSingle={true}
-            onChange={handleValueChange}
-            containerClassName={className}
-            displayFormat={"DD/MM/YYYY"}
-        />
+        <div className={className}>
+            <DatePicker
+                onChange={onChange}
+                value={value}
+                locale="es-UY"
+                format="dd/MM/yyyy"
+                className="mt-1 block w-full text-stone-800 font-bold kimput"
+                calendarClassName="bg-white border rounded-lg shadow-lg"
+                clearIcon={null}
+            />
+        </div>
     );
 }


### PR DESCRIPTION
### Descrição:

### Contexto
O componente de calendário anterior (react-tailwindcss-datepicker) apresentava bugs visuais de renderização e possuía uma lógica de manipulação de dados baseada em Acoplamento Rígido. O sistema dependia de strings estáticas e processamento manual via Regex para formatar as datas entre a interface e o banco de dados.

### Alterações Técnicas

- Substituição de Dependência: Migração para a biblioteca react-date-picker, garantindo estabilidade visual e consistência com os filtros já existentes no site.
- Migração para POO Nativa: Refatoração do useState para armazenar instâncias da classe Date em vez de strings. Isso transformou o dado em uma "entidade inteligente", permitindo uma manipulação mais fluida e segura.
- Eliminação de Fragilidade: Remoção completa de expressões regulares (Regex) para inversão de datas. Agora, o contrato de interface com o backend (formato YYYY-MM-DD) é garantido nativamente pelo método .toLocaleDateString('en-CA').

### Impacto
O código tornou-se mais ortogonal, separando claramente as responsabilidades de exibição (UI) e persistência (Backend). Isso reduz a dívida técnica e elimina falhas silenciosas causadas por inconsistências de formato de texto.