### PR TITLE
fix: forçar HTTPS e HSTS para eliminar aviso de conexão insegura

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+# Produção (Cloudflare): APP_URL=https://destinobinacional.com e FORCE_HTTPS=true
+FORCE_HTTPS=false
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends HttpKernel
     protected $middleware = [
         // \App\Http\Middleware\TrustHosts::class,
         \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\ForceHttps::class,
         \App\Http\Middleware\ForceRequestRootUrl::class,
         \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,

--- a/app/Http/Middleware/ForceHttps.php
+++ b/app/Http/Middleware/ForceHttps.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ForceHttps
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $this->shouldForceHttps()) {
+            return $next($request);
+        }
+
+        if (! $request->secure()) {
+            return redirect()->secure($request->getRequestUri(), 301);
+        }
+
+        $response = $next($request);
+
+        $response->headers->set(
+            'Strict-Transport-Security',
+            'max-age=31536000; includeSubDomains; preload'
+        );
+
+        return $response;
+    }
+
+    private function shouldForceHttps(): bool
+    {
+        return app()->environment('production')
+            || (bool) config('app.force_https', false);
+    }
+}

--- a/app/Http/Middleware/ForceRequestRootUrl.php
+++ b/app/Http/Middleware/ForceRequestRootUrl.php
@@ -15,6 +15,10 @@ class ForceRequestRootUrl
      */
     public function handle(Request $request, Closure $next): Response
     {
+        if (app()->environment('production') || config('app.force_https')) {
+            URL::forceScheme('https');
+        }
+
         URL::forceRootUrl($request->root());
 
         return $next($request);

--- a/app/Http/Middleware/TrustProxies.php
+++ b/app/Http/Middleware/TrustProxies.php
@@ -12,7 +12,7 @@ class TrustProxies extends Middleware
      *
      * @var array<int, string>|string|null
      */
-    protected $proxies;
+    protected $proxies = '*';
 
     /**
      * The headers that should be used to detect proxies.

--- a/config/app.php
+++ b/config/app.php
@@ -56,6 +56,8 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
+    'force_https' => (bool) env('FORCE_HTTPS', false),
+
     'asset_url' => env('ASSET_URL'),
 
     /*

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,8 @@ services:
     environment:
       - APP_ENV=production
       - APP_DEBUG=false
+      - APP_URL=https://destinobinacional.com
+      - FORCE_HTTPS=true
       - LOG_CHANNEL=stack
       - DB_CONNECTION=mysql
       - DB_HOST=mysql

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -3,6 +3,11 @@ server {
     server_name _;
     root /var/www/public;
 
+    # Cloudflare / reverse proxy: redireciona HTTP do visitante antes do PHP
+    if ($http_x_forwarded_proto = "http") {
+        return 301 https://$host$request_uri;
+    }
+
     add_header X-Frame-Options "SAMEORIGIN";
     add_header X-Content-Type-Options "nosniff";
 

--- a/tests/Unit/Http/Middleware/ForceHttpsTest.php
+++ b/tests/Unit/Http/Middleware/ForceHttpsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit\Http\Middleware;
+
+use App\Http\Middleware\ForceHttps;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Symfony\Component\HttpFoundation\Response;
+use Tests\TestCase;
+
+class ForceHttpsTest extends TestCase
+{
+    private function trustedRequest(string $uri, string $forwardedProto): Request
+    {
+        $request = Request::create($uri, 'GET');
+        $request->headers->set('X-Forwarded-Proto', $forwardedProto);
+        $request->setTrustedProxies(['*'], Request::HEADER_X_FORWARDED_PROTO);
+
+        return $request;
+    }
+
+    public function test_redirects_insecure_requests_to_https(): void
+    {
+        Config::set('app.force_https', true);
+
+        $middleware = new ForceHttps;
+        $response = $middleware->handle(
+            $this->trustedRequest('http://destinobinacional.com/?utm_source=ig', 'http'),
+            fn (): Response => response('ok')
+        );
+
+        $this->assertSame(301, $response->getStatusCode());
+        $this->assertStringStartsWith('https://', $response->headers->get('Location'));
+    }
+
+    public function test_adds_hsts_header_on_secure_requests(): void
+    {
+        Config::set('app.force_https', true);
+
+        $middleware = new ForceHttps;
+        $response = $middleware->handle(
+            $this->trustedRequest('https://destinobinacional.com/', 'https'),
+            fn (): Response => response('ok')
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(
+            'max-age=31536000; includeSubDomains; preload',
+            $response->headers->get('Strict-Transport-Security')
+        );
+    }
+
+    public function test_does_not_force_https_when_disabled(): void
+    {
+        Config::set('app.force_https', false);
+        Config::set('app.env', 'local');
+
+        $middleware = new ForceHttps;
+        $response = $middleware->handle(
+            $this->trustedRequest('http://destinobinacional.com/', 'http'),
+            fn (): Response => response('ok')
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertNull($response->headers->get('Strict-Transport-Security'));
+    }
+}


### PR DESCRIPTION
## Problema

Visitantes que clicavam no link do Instagram (cadastrado com `http://`) recebiam o aviso do Chrome **"This site doesn't support a secure connection"**, bloqueando o acesso ao site.

## O que foi feito

- **`ForceHttps` middleware** — em produção redireciona qualquer request HTTP → HTTPS (301) e adiciona o header `Strict-Transport-Security` (HSTS, 1 ano, includeSubDomains, preload)
- **`TrustProxies`** — confia em todos os proxies (`*`) para ler corretamente o header `X-Forwarded-Proto` do Cloudflare
- **`ForceRequestRootUrl`** — aplica `URL::forceScheme('https')` em produção para garantir que `url()` e `asset()` gerem URLs HTTPS
- **Nginx** — redireciona HTTP para HTTPS na borda via `X-Forwarded-Proto`, antes de chegar ao PHP
- **`docker-compose.prod.yml`** — define `APP_URL=https://destinobinacional.com` e `FORCE_HTTPS=true`
- **`config/app.php`** — chave `force_https` configurável via env `FORCE_HTTPS`
- **Testes** — 3 casos unitários cobrindo redirect, HSTS e modo desativado

## Deploy

No servidor de produção após merge:

```bash
git pull
docker compose -f docker-compose.prod.yml up -d --build
```

Confirmar no `.env` de produção:
```
APP_URL=https://destinobinacional.com
FORCE_HTTPS=true
```

## Ação pendente (fora do código)

Atualizar o link da bio do Instagram de `http://www.destinobinacional.com/` para:
```
https://destinobinacional.com/?utm_source=ig&utm_medium=social&utm_content=link_in_bio
```

Made with [Cursor](https://cursor.com)