### PR TITLE
fix: upload de imagens fail-fast e diagnóstico de storage

### DIFF
--- a/app/Console/Commands/CheckPublicStorage.php
+++ b/app/Console/Commands/CheckPublicStorage.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Event;
+use App\Models\Place;
+use App\Models\Tour;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
+class CheckPublicStorage extends Command
+{
+    protected $signature = 'storage:check-public';
+
+    protected $description = 'Verifica symlink public/storage, permissões e registos órfãos (DB sem ficheiro)';
+
+    public function handle(): int
+    {
+        $ok = true;
+
+        $linkPath = public_path('storage');
+        $targetPath = storage_path('app/public');
+
+        if (! File::exists($linkPath)) {
+            $this->error('Symlink em falta: public/storage');
+            $this->line('Execute: php artisan storage:link --force');
+            $ok = false;
+        } elseif (! is_link($linkPath)) {
+            $this->error('public/storage existe mas não é symlink (pode ser pasta estática desatualizada).');
+            $ok = false;
+        } else {
+            $resolved = realpath($linkPath);
+            $expected = realpath($targetPath);
+            if ($resolved !== $expected) {
+                $this->error("Symlink aponta para {$resolved}, esperado {$expected}");
+                $ok = false;
+            } else {
+                $this->info('Symlink public/storage → storage/app/public OK');
+            }
+        }
+
+        foreach (['events', 'places', 'tours', 'categories'] as $directory) {
+            $relative = $directory;
+            if (! Storage::disk('public')->exists($relative)) {
+                Storage::disk('public')->makeDirectory($relative);
+                $this->warn("Diretório criado: storage/app/public/{$relative}");
+            }
+
+            $fullPath = storage_path('app/public/'.$relative);
+            if (! is_writable($fullPath)) {
+                $this->error("Sem permissão de escrita: {$fullPath}");
+                $ok = false;
+            } else {
+                $this->info("Escrita OK: storage/app/public/{$relative}");
+            }
+        }
+
+        $orphans = $this->findOrphanRecords();
+        if ($orphans === []) {
+            $this->info('Nenhum registo órfão (featured_image sem ficheiro).');
+        } else {
+            $ok = false;
+            $this->warn('Registos com featured_image mas ficheiro em falta:');
+            foreach ($orphans as $line) {
+                $this->line("  - {$line}");
+            }
+        }
+
+        return $ok ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function findOrphanRecords(): array
+    {
+        $lines = [];
+
+        Event::query()
+            ->whereNotNull('featured_image')
+            ->where('featured_image', '!=', '')
+            ->get(['id', 'featured_image'])
+            ->each(function (Event $event) use (&$lines) {
+                if (! Storage::disk('public')->exists('events/'.$event->featured_image)) {
+                    $lines[] = "Event #{$event->id} events/{$event->featured_image}";
+                }
+            });
+
+        Place::query()
+            ->whereNotNull('featured_image')
+            ->where('featured_image', '!=', '')
+            ->get(['id', 'featured_image'])
+            ->each(function (Place $place) use (&$lines) {
+                if (! Storage::disk('public')->exists('places/'.$place->featured_image)) {
+                    $lines[] = "Place #{$place->id} places/{$place->featured_image}";
+                }
+            });
+
+        Tour::query()
+            ->whereNotNull('featured_image')
+            ->where('featured_image', '!=', '')
+            ->get(['id', 'featured_image'])
+            ->each(function (Tour $tour) use (&$lines) {
+                if (! Storage::disk('public')->exists('tours/'.$tour->featured_image)) {
+                    $lines[] = "Tour #{$tour->id} tours/{$tour->featured_image}";
+                }
+            });
+
+        return $lines;
+    }
+}

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -10,6 +10,7 @@ use App\Services\EventService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
+use RuntimeException;
 
 class EventController extends Controller
 {
@@ -82,7 +83,13 @@ class EventController extends Controller
             'tag_ids' => 'required',
         ]);
 
-        $this->eventService->store($validated);
+        try {
+            $this->eventService->store($validated);
+        } catch (RuntimeException) {
+            return back()
+                ->withErrors(['featured_image' => 'No se pudo guardar la imagen del evento. Verifique permisos de storage e intente de nuevo.'])
+                ->withInput();
+        }
 
         return redirect()->route('events.index')
             ->with('success', 'Evento creado con éxito.');
@@ -126,7 +133,13 @@ class EventController extends Controller
             'tag_ids' => ['required', 'array'],
         ]);
 
-        $this->eventService->update($validated, $event);
+        try {
+            $this->eventService->update($validated, $event);
+        } catch (RuntimeException) {
+            return back()
+                ->withErrors(['featured_image' => 'No se pudo guardar la imagen del evento. Verifique permisos de storage e intente de nuevo.'])
+                ->withInput();
+        }
 
         return redirect()->route('events.index')
             ->with('success', 'Evento actualizado con éxito.');

--- a/app/Services/CategoryService.php
+++ b/app/Services/CategoryService.php
@@ -8,6 +8,7 @@ use App\Repositories\CategoryRepository;
 use Exception;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Intervention\Image\Facades\Image;
@@ -16,6 +17,7 @@ class CategoryService
 {
     public function __construct(
         protected CategoryRepository $categoryRepository = new CategoryRepository,
+        protected FeaturedImageStorage $featuredImageStorage = new FeaturedImageStorage,
     ) {}
 
     public function index(): Collection
@@ -40,50 +42,42 @@ class CategoryService
 
     public function store(array $validated)
     {
-        $category = Category::create([
-            'featured_image' => Arr::get($validated, 'image', false) ? $this->storeFeaturedImage($validated['image']) : 'icons/default.svg',
-            'color' => Arr::get($validated, 'color', null),
-            'icon' => Arr::get($validated, 'icon_image', false) ? $this->storeIcon($validated['icon_image']) : 'turistico.webp',
-            'parent_id' => Arr::get($validated, 'parent_id', false),
-        ]);
+        return DB::transaction(function () use ($validated) {
+            $category = Category::create([
+                'featured_image' => Arr::get($validated, 'image', false) ? $this->storeFeaturedImage($validated['image']) : 'icons/default.svg',
+                'color' => Arr::get($validated, 'color', null),
+                'icon' => Arr::get($validated, 'icon_image', false) ? $this->storeIcon($validated['icon_image']) : 'turistico.webp',
+                'parent_id' => Arr::get($validated, 'parent_id', false),
+            ]);
 
-        CategoryTranslation::create([
-            'locale' => 'es',
-            'name' => $validated['name_es'],
-            'slug' => Str::slug($validated['name_es']),
-            'category_id' => $category->id,
-        ]);
+            CategoryTranslation::create([
+                'locale' => 'es',
+                'name' => $validated['name_es'],
+                'slug' => Str::slug($validated['name_es']),
+                'category_id' => $category->id,
+            ]);
 
-        CategoryTranslation::create([
-            'locale' => 'pt',
-            'name' => $validated['name_pt'],
-            'slug' => Str::slug($validated['name_pt']),
-            'category_id' => $category->id,
-        ]);
+            CategoryTranslation::create([
+                'locale' => 'pt',
+                'name' => $validated['name_pt'],
+                'slug' => Str::slug($validated['name_pt']),
+                'category_id' => $category->id,
+            ]);
 
-        return $category;
+            return $category;
+        });
     }
 
-    public function storeFeaturedImage($image): string
+    public function storeFeaturedImage($image): ?string
     {
-        if (! $image || is_null($image)) {
-            return null;
-        }
+        $config = config('custom.categories_feature_image');
 
-        $width = config('custom.feature_image.width');
-        $height = config('custom.feature_image.height');
-        $path = config('custom.categories_feature_image.path');
-        $featured_image_src = null;
-
-        try {
-            $file = base64_decode(preg_replace('#^data:image/\w+;base64,#i', '', $image));
-            $featured_image_src = 'place_'.time().'.'.explode('/', explode(':', substr($image, 0, strpos($image, ';')))[1])[1];
-            Image::make($file)->resize($width, $height)->save(storage_path('app/public/'.$path.$featured_image_src));
-        } catch (Exception $e) {
-            Log::error($e);
-        }
-
-        return $featured_image_src;
+        return $this->featuredImageStorage->storeFromBase64($image, [
+            'path' => $config['path'],
+            'prefix' => 'place_',
+            'width' => $config['width'],
+            'height' => $config['height'],
+        ]);
     }
 
     public function storeIcon($icon)
@@ -114,45 +108,47 @@ class CategoryService
 
     public function update(array $validated, Category $category)
     {
-        $category->update([
-            'featured_image' => Arr::get($validated, 'image', false) ? $this->storeFeaturedImage($validated['image']) : $category->getRawOriginal('featured_image'),
-            'color' => Arr::get($validated, 'color', false) ? $validated['color'] : $category->color,
-            'icon' => Arr::get($validated, 'icon_image', false) ? $this->storeIcon($validated['icon_image']) : $category->getRawOriginal('icon'),
-            'parent_id' => Arr::get($validated, 'parent_id', false) ? $validated['parent_id'] : $category->parent_id,
-        ]);
+        return DB::transaction(function () use ($validated, $category) {
+            $category->update([
+                'featured_image' => Arr::get($validated, 'image', false) ? $this->storeFeaturedImage($validated['image']) : $category->getRawOriginal('featured_image'),
+                'color' => Arr::get($validated, 'color', false) ? $validated['color'] : $category->color,
+                'icon' => Arr::get($validated, 'icon_image', false) ? $this->storeIcon($validated['icon_image']) : $category->getRawOriginal('icon'),
+                'parent_id' => Arr::get($validated, 'parent_id', false) ? $validated['parent_id'] : $category->parent_id,
+            ]);
 
-        $cat = CategoryTranslation::firstOrCreate(
-            [
-                'category_id' => $category->id,
-                'locale' => 'es',
-            ],
-            [
+            $cat = CategoryTranslation::firstOrCreate(
+                [
+                    'category_id' => $category->id,
+                    'locale' => 'es',
+                ],
+                [
+                    'name' => $validated['name_es'],
+                    'slug' => Str::slug($validated['name_es']),
+                ]
+            );
+
+            $cat->update([
                 'name' => $validated['name_es'],
                 'slug' => Str::slug($validated['name_es']),
-            ]
-        );
+            ]);
 
-        $cat->update([
-            'name' => $validated['name_es'],
-            'slug' => Str::slug($validated['name_es']),
-        ]);
+            $cat2 = CategoryTranslation::firstOrCreate(
+                [
+                    'category_id' => $category->id,
+                    'locale' => 'pt',
+                ],
+                [
+                    'name' => $validated['name_pt'],
+                    'slug' => Str::slug($validated['name_pt']),
+                ]
+            );
 
-        $cat2 = CategoryTranslation::firstOrCreate(
-            [
-                'category_id' => $category->id,
-                'locale' => 'pt',
-            ],
-            [
+            $cat2->update([
                 'name' => $validated['name_pt'],
                 'slug' => Str::slug($validated['name_pt']),
-            ]
-        );
+            ]);
 
-        $cat2->update([
-            'name' => $validated['name_pt'],
-            'slug' => Str::slug($validated['name_pt']),
-        ]);
-
-        return $category;
+            return $category;
+        });
     }
 }

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -5,11 +5,9 @@ namespace App\Services;
 use App\Models\Event;
 use App\Repositories\EventRepository;
 use Carbon\Carbon;
-use Exception;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Intervention\Image\Facades\Image;
 
 class EventService
 {
@@ -17,6 +15,7 @@ class EventService
 
     public function __construct(
         protected EventRepository $eventRepository = new EventRepository,
+        protected FeaturedImageStorage $featuredImageStorage = new FeaturedImageStorage,
     ) {}
 
     public function index()
@@ -41,76 +40,70 @@ class EventService
 
     public function store(array $data): Event
     {
-        $event = Event::create([
-            'title' => Arr::get($data, 'title'),
-            'slug' => Str::slug(Arr::get($data, 'title')),
-            'description' => Arr::get($data, 'description'),
-            'start' => Carbon::parse(Arr::get($data, 'start')),
-            'end' => Carbon::parse(Arr::get($data, 'end')),
-            'is_online' => Arr::get($data, 'is_online'),
-            'link' => Arr::get($data, 'link'),
-            'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')),
-            'address' => Arr::get($data, 'address'),
-            'city_id' => Arr::get($data, 'city_id'),
-            'category_id' => Arr::get($data, 'category_id'),
-            'featured_image' => $this->storeFeaturedImage(Arr::get($data, 'featured_image')),
-        ]);
+        return DB::transaction(function () use ($data) {
+            $event = Event::create([
+                'title' => Arr::get($data, 'title'),
+                'slug' => Str::slug(Arr::get($data, 'title')),
+                'description' => Arr::get($data, 'description'),
+                'start' => Carbon::parse(Arr::get($data, 'start')),
+                'end' => Carbon::parse(Arr::get($data, 'end')),
+                'is_online' => Arr::get($data, 'is_online'),
+                'link' => Arr::get($data, 'link'),
+                'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')),
+                'address' => Arr::get($data, 'address'),
+                'city_id' => Arr::get($data, 'city_id'),
+                'category_id' => Arr::get($data, 'category_id'),
+                'featured_image' => $this->storeFeaturedImage(Arr::get($data, 'featured_image')),
+            ]);
 
-        $event->tags()->sync(Arr::get($data, 'tag_ids'));
+            $event->tags()->sync(Arr::get($data, 'tag_ids'));
 
-        return $event;
+            return $event;
+        });
     }
 
     public function storeFeaturedImage($image): ?string
     {
-        if (! $image || is_null($image)) {
-            return null;
-        }
+        $config = config('custom.events_feature_image');
 
-        $width = config('custom.feature_image.width');
-        $height = config('custom.feature_image.height');
-
-        $featured_image_src = null;
-
-        try {
-            $file = base64_decode(preg_replace('#^data:image/\w+;base64,#i', '', $image));
-            $featured_image_src = 'event_'.time().'.'.explode('/', explode(':', substr($image, 0, strpos($image, ';')))[1])[1];
-            // Image::make($file)->resize($width, $height)->save(storage_path('app/public/'.'events/'.$featured_image_src));
-            Image::make($file)->save(storage_path('app/public/'.'events/'.$featured_image_src));
-        } catch (Exception $e) {
-            Log::error($e);
-        }
-
-        return $featured_image_src;
+        return $this->featuredImageStorage->storeFromBase64($image, [
+            'path' => $config['path'],
+            'prefix' => 'event_',
+            'width' => $config['width'],
+            'height' => $config['height'],
+        ]);
     }
 
     public function update(array $data, Event $event)
     {
-        // upload image
-        if (! is_null(Arr::get($data, 'featured_image'))) {
-            $the_feature_image = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
-        }
+        return DB::transaction(function () use ($data, $event) {
+            $the_feature_image = null;
 
-        $event->update([
-            'title' => Arr::get($data, 'title'),
-            'slug' => Str::slug(Arr::get($data, 'title')),
-            'description' => Arr::get($data, 'description'),
-            'start' => Carbon::parse(Arr::get($data, 'start')),
-            'end' => Carbon::parse(Arr::get($data, 'end')),
-            'is_online' => Arr::get($data, 'is_online'),
-            'link' => Arr::get($data, 'link'),
-            'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')) ?? $event->google_maps_src,
-            'address' => Arr::get($data, 'address'),
-            'city_id' => Arr::get($data, 'city_id'),
-            'category_id' => Arr::get($data, 'category_id'),
-            'featured_image' => $the_feature_image ?? $event->featured_image,
-        ]);
+            if (! is_null(Arr::get($data, 'featured_image'))) {
+                $the_feature_image = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
+            }
 
-        if (array_key_exists('tag_ids', $data)) {
-            $event->tags()->sync(Arr::get($data, 'tag_ids', []));
-        }
+            $event->update([
+                'title' => Arr::get($data, 'title'),
+                'slug' => Str::slug(Arr::get($data, 'title')),
+                'description' => Arr::get($data, 'description'),
+                'start' => Carbon::parse(Arr::get($data, 'start')),
+                'end' => Carbon::parse(Arr::get($data, 'end')),
+                'is_online' => Arr::get($data, 'is_online'),
+                'link' => Arr::get($data, 'link'),
+                'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')) ?? $event->google_maps_src,
+                'address' => Arr::get($data, 'address'),
+                'city_id' => Arr::get($data, 'city_id'),
+                'category_id' => Arr::get($data, 'category_id'),
+                'featured_image' => $the_feature_image ?? $event->featured_image,
+            ]);
 
-        return $event;
+            if (array_key_exists('tag_ids', $data)) {
+                $event->tags()->sync(Arr::get($data, 'tag_ids', []));
+            }
+
+            return $event;
+        });
     }
 
     public function destroy(Event $event)

--- a/app/Services/FeaturedImageStorage.php
+++ b/app/Services/FeaturedImageStorage.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Facades\Image;
+use RuntimeException;
+use Throwable;
+
+class FeaturedImageStorage
+{
+    /**
+     * Persist a base64 data-URI image on the public disk.
+     *
+     * @param  array{path: string, prefix: string, width?: int|null, height?: int|null}  $options
+     *
+     * @throws RuntimeException
+     */
+    public function storeFromBase64(?string $image, array $options): ?string
+    {
+        if ($image === null || trim($image) === '') {
+            return null;
+        }
+
+        $directory = trim($options['path'], '/');
+        $prefix = $options['prefix'];
+        $width = $options['width'] ?? null;
+        $height = $options['height'] ?? null;
+
+        $extension = $this->extensionFromDataUri($image);
+        $filename = $prefix.time().'.'.$extension;
+        $relativePath = $directory.'/'.$filename;
+
+        $decoded = base64_decode(
+            (string) preg_replace('#^data:image/\w+;base64,#i', '', $image),
+            true
+        );
+
+        if ($decoded === false) {
+            throw new RuntimeException('Invalid base64 image data.');
+        }
+
+        Storage::disk('public')->makeDirectory($directory);
+
+        try {
+            $imageInstance = Image::make($decoded);
+
+            if ($width !== null && $height !== null) {
+                $imageInstance->resize($width, $height);
+            }
+
+            $imageInstance->save(storage_path('app/public/'.$relativePath));
+        } catch (Throwable $e) {
+            Log::error('Featured image save failed', [
+                'path' => $relativePath,
+                'message' => $e->getMessage(),
+            ]);
+
+            throw new RuntimeException('Could not save featured image.', 0, $e);
+        }
+
+        if (! Storage::disk('public')->exists($relativePath)) {
+            throw new RuntimeException('Featured image was not written to disk.');
+        }
+
+        return $filename;
+    }
+
+    /**
+     * @throws RuntimeException
+     */
+    private function extensionFromDataUri(string $dataUri): string
+    {
+        $semicolon = strpos($dataUri, ';');
+        if ($semicolon === false) {
+            throw new RuntimeException('Invalid image data URI.');
+        }
+
+        $mimePart = explode(':', substr($dataUri, 0, $semicolon))[1] ?? '';
+        $extension = explode('/', $mimePart)[1] ?? '';
+
+        if ($extension === '') {
+            throw new RuntimeException('Could not detect image type.');
+        }
+
+        return $extension;
+    }
+}

--- a/app/Services/PlaceService.php
+++ b/app/Services/PlaceService.php
@@ -5,12 +5,10 @@ namespace App\Services;
 use App\Models\Place;
 use App\Models\PlaceTranslation;
 use App\Repositories\PlaceRepository;
-use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Intervention\Image\Facades\Image;
 
 class PlaceService
 {
@@ -18,6 +16,7 @@ class PlaceService
 
     public function __construct(
         protected PlaceRepository $placeRepository = new PlaceRepository,
+        protected FeaturedImageStorage $featuredImageStorage = new FeaturedImageStorage,
     ) {}
 
     public function index()
@@ -27,100 +26,94 @@ class PlaceService
 
     public function store(array $data, Request $request)
     {
-        // upload image
-        $featured_image_src = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
+        return DB::transaction(function () use ($data) {
+            $featured_image_src = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
 
-        $place = Place::create([
-            'name' => Arr::get($data, 'name'),
-            'slug' => Str::slug(Arr::get($data, 'name')),
-            'address' => Arr::get($data, 'address'),
-            'city_id' => Arr::get($data, 'city_id'),
-            'category_id' => Arr::get($data, 'category_id'),
-            'featured_image' => $featured_image_src,
-            'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')) ?? 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2035.7206938642744!2d-55.53435751721623!3d-30.89615794116233!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x95a9fe587b122a5b%3A0xa18c901cc947fe5a!2sPlaza%20Internacional!5e0!3m2!1ses-419!2sbr!4v1687316146073!5m2!1ses-419!2sbr',
-            'order' => Arr::get($data, 'order') ? (int) Arr::get($data, 'order') : 0,
-        ]);
+            $place = Place::create([
+                'name' => Arr::get($data, 'name'),
+                'slug' => Str::slug(Arr::get($data, 'name')),
+                'address' => Arr::get($data, 'address'),
+                'city_id' => Arr::get($data, 'city_id'),
+                'category_id' => Arr::get($data, 'category_id'),
+                'featured_image' => $featured_image_src,
+                'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')) ?? 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2035.7206938642744!2d-55.53435751721623!3d-30.89615794116233!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x95a9fe587b122a5b%3A0xa18c901cc947fe5a!2sPlaza%20Internacional!5e0!3m2!1ses-419!2sbr!4v1687316146073!5m2!1ses-419!2sbr',
+                'order' => Arr::get($data, 'order') ? (int) Arr::get($data, 'order') : 0,
+            ]);
 
-        if (! $place) {
-            $this->error_message = 'Error creating place';
+            if (! $place) {
+                $this->error_message = 'Error creating place';
 
-            return false;
-        }
+                return false;
+            }
 
-        PlaceTranslation::create([
-            'place_id' => $place->id,
-            'locale' => 'pt',
-            'description' => $data['description_pt'],
-        ]);
+            PlaceTranslation::create([
+                'place_id' => $place->id,
+                'locale' => 'pt',
+                'description' => $data['description_pt'],
+            ]);
 
-        PlaceTranslation::create([
-            'place_id' => $place->id,
-            'locale' => 'es',
-            'description' => $data['description_es'],
-        ]);
+            PlaceTranslation::create([
+                'place_id' => $place->id,
+                'locale' => 'es',
+                'description' => $data['description_es'],
+            ]);
 
-        $place->categories()->sync(Arr::get($data, 'category_ids'));
+            $place->categories()->sync(Arr::get($data, 'category_ids'));
 
-        return $place;
+            return $place;
+        });
     }
 
     public function storeFeaturedImage($image): ?string
     {
-        if (! $image || is_null($image)) {
-            return null;
-        }
+        $config = config('custom.feature_image');
 
-        $width = config('custom.feature_image.width');
-        $height = config('custom.feature_image.height');
-        $path = config('custom.feature_image.path');
-        $featured_image_src = null;
-
-        try {
-            $file = base64_decode(preg_replace('#^data:image/\w+;base64,#i', '', $image));
-            $featured_image_src = 'place_'.time().'.'.explode('/', explode(':', substr($image, 0, strpos($image, ';')))[1])[1];
-            Image::make($file)->resize($width, $height)->save(storage_path('app/public/'.$path.$featured_image_src));
-        } catch (Exception $e) {
-            Log::error($e);
-        }
-
-        return $featured_image_src;
+        return $this->featuredImageStorage->storeFromBase64($image, [
+            'path' => $config['path'],
+            'prefix' => 'place_',
+            'width' => $config['width'],
+            'height' => $config['height'],
+        ]);
     }
 
     public function update(array $data, Request $request, Place $place)
     {
-        // upload image
-        if ($request->has('featured_image')
-            && ! is_null($request->featured_image)
-            && ! is_null(Arr::get($data, 'featured_image'))
-        ) {
-            $the_feature_image = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
-        }
+        return DB::transaction(function () use ($data, $request, $place) {
+            $the_feature_image = null;
 
-        $place->update([
-            'name' => Arr::get($data, 'name'),
-            'slug' => Str::slug(Arr::get($data, 'name')),
-            'address' => Arr::get($data, 'address'),
-            'city_id' => Arr::get($data, 'city_id'),
-            'place_type_id' => Arr::get($data, 'place_type_id'),
-            'category_id' => Arr::get($data, 'category_id'),
-            'featured_image' => $the_feature_image ?? $place->featured_image,
-            'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')) ?? $place->google_maps_src,
-            'order' => Arr::get($data, 'order') ?? 0,
-        ]);
+            if ($request->has('featured_image')
+                && ! is_null($request->featured_image)
+                && ! is_null(Arr::get($data, 'featured_image'))
+            ) {
+                $the_feature_image = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
+            }
 
-        PlaceTranslation::updateOrCreate(
-            ['place_id' => $place->id, 'locale' => 'pt'],
-            ['description' => $data['description_pt']]
-        );
+            $place->update([
+                'name' => Arr::get($data, 'name'),
+                'slug' => Str::slug(Arr::get($data, 'name')),
+                'address' => Arr::get($data, 'address'),
+                'city_id' => Arr::get($data, 'city_id'),
+                'place_type_id' => Arr::get($data, 'place_type_id'),
+                'category_id' => Arr::get($data, 'category_id'),
+                'featured_image' => $the_feature_image ?? $place->featured_image,
+                'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')) ?? $place->google_maps_src,
+                'order' => Arr::get($data, 'order') ?? 0,
+            ]);
 
-        PlaceTranslation::updateOrCreate(
-            ['place_id' => $place->id, 'locale' => 'es'],
-            ['description' => $data['description_es']]
-        );
+            PlaceTranslation::updateOrCreate(
+                ['place_id' => $place->id, 'locale' => 'pt'],
+                ['description' => $data['description_pt']]
+            );
 
-        $place->categories()->sync(Arr::get($data, 'category_ids'));
+            PlaceTranslation::updateOrCreate(
+                ['place_id' => $place->id, 'locale' => 'es'],
+                ['description' => $data['description_es']]
+            );
 
-        return $place;
+            $place->categories()->sync(Arr::get($data, 'category_ids'));
+
+            return $place;
+        });
     }
 
     public function getByCategoryParentID(int $CategoryParentId)

--- a/app/Services/TourService.php
+++ b/app/Services/TourService.php
@@ -4,11 +4,9 @@ namespace App\Services;
 
 use App\Models\Tour;
 use App\Repositories\TourRepository;
-use Exception;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
-use Intervention\Image\Facades\Image;
 
 class TourService
 {
@@ -16,6 +14,7 @@ class TourService
 
     public function __construct(
         protected TourRepository $tourRepository = new TourRepository,
+        protected FeaturedImageStorage $featuredImageStorage = new FeaturedImageStorage,
     ) {}
 
     public function index()
@@ -30,91 +29,83 @@ class TourService
 
     public function store(array $data)
     {
-        // upload image
-        $featured_image_src = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
-        $google_maps_src = Arr::get($data, 'google_maps_src');
-        $google_maps_src = extractSrcFromGmapsIframe($google_maps_src);
-        $google_maps_src = $google_maps_src ?? config('custom.default_map_src');
+        return DB::transaction(function () use ($data) {
+            $featured_image_src = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
+            $google_maps_src = Arr::get($data, 'google_maps_src');
+            $google_maps_src = extractSrcFromGmapsIframe($google_maps_src);
+            $google_maps_src = $google_maps_src ?? config('custom.default_map_src');
 
-        $tour = Tour::create([
-            'title' => Arr::get($data, 'title'),
-            'slug' => Str::slug(Arr::get($data, 'title')),
-            'description' => Arr::get($data, 'description'),
-            'featured_image' => $featured_image_src,
-            'google_maps_src' => $google_maps_src,
-            'start' => Arr::get($data, 'start'),
-            'end' => Arr::get($data, 'end'),
-            'price' => Arr::get($data, 'price') ? convert_to_cents(Arr::get($data, 'price')) : 0,
-            'currency' => Arr::get($data, 'currency', 'BRL'),
-            'guide' => Arr::get($data, 'guide'),
-            'meeting_point' => Arr::get($data, 'meeting_point'),
-            'recurrence_enabled' => Arr::get($data, 'recurrence_enabled', false),
-            'recurrence_day_hour' => Arr::get($data, 'recurrence_day_hour'),
-        ]);
+            $tour = Tour::create([
+                'title' => Arr::get($data, 'title'),
+                'slug' => Str::slug(Arr::get($data, 'title')),
+                'description' => Arr::get($data, 'description'),
+                'featured_image' => $featured_image_src,
+                'google_maps_src' => $google_maps_src,
+                'start' => Arr::get($data, 'start'),
+                'end' => Arr::get($data, 'end'),
+                'price' => Arr::get($data, 'price') ? convert_to_cents(Arr::get($data, 'price')) : 0,
+                'currency' => Arr::get($data, 'currency', 'BRL'),
+                'guide' => Arr::get($data, 'guide'),
+                'meeting_point' => Arr::get($data, 'meeting_point'),
+                'recurrence_enabled' => Arr::get($data, 'recurrence_enabled', false),
+                'recurrence_day_hour' => Arr::get($data, 'recurrence_day_hour'),
+            ]);
 
-        if (! $tour) {
-            $this->error_message = 'Error creating place';
+            if (! $tour) {
+                $this->error_message = 'Error creating place';
 
-            return false;
-        }
+                return false;
+            }
 
-        $tour->categories()->sync(Arr::get($data, 'category_ids'));
+            $tour->categories()->sync(Arr::get($data, 'category_ids'));
 
-        return $tour;
+            return $tour;
+        });
     }
 
     public function storeFeaturedImage($image): ?string
     {
-        if (! $image || is_null($image)) {
-            return null;
-        }
+        $config = config('custom.tours_feature_image');
 
-        $width = config('custom.tours_feature_image.width');
-        $height = config('custom.tours_feature_image.height');
-        $path = config('custom.tours_feature_image.path');
-        $featured_image_src = null;
-
-        try {
-            $file = base64_decode(preg_replace('#^data:image/\w+;base64,#i', '', $image));
-            $featured_image_src = 'tour_'.time().'.'.explode('/', explode(':', substr($image, 0, strpos($image, ';')))[1])[1];
-            Image::make($file)->resize($width, $height)->save(storage_path('app/public/'.$path.$featured_image_src));
-        } catch (Exception $e) {
-            Log::error($e);
-        }
-
-        return $featured_image_src;
+        return $this->featuredImageStorage->storeFromBase64($image, [
+            'path' => $config['path'],
+            'prefix' => 'tour_',
+            'width' => $config['width'],
+            'height' => $config['height'],
+        ]);
     }
 
     public function update(array $data, Tour $tour): Tour
     {
-        $the_feature_image = null;
-        $start = Arr::get($data, 'start', null);
-        $end = Arr::get($data, 'end', null);
+        return DB::transaction(function () use ($data, $tour) {
+            $the_feature_image = null;
+            $start = Arr::get($data, 'start', null);
+            $end = Arr::get($data, 'end', null);
 
-        // upload image
-        if (! is_null(Arr::get($data, 'featured_image'))) {
-            $the_feature_image = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
-        }
+            if (! is_null(Arr::get($data, 'featured_image'))) {
+                $the_feature_image = $this->storeFeaturedImage(Arr::get($data, 'featured_image'));
+            }
 
-        $tour->update([
-            'title' => Arr::get($data, 'title'),
-            'slug' => Str::slug(Arr::get($data, 'title')),
-            'description' => Arr::get($data, 'description'),
-            'featured_image' => $the_feature_image ?? $tour->featured_image,
-            'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')) ?? $tour->google_maps_src,
-            'start' => $start,
-            'end' => $end,
-            'price' => Arr::get($data, 'price') ? convert_to_cents(Arr::get($data, 'price')) : 0,
-            'currency' => Arr::get($data, 'currency'),
-            'guide' => Arr::get($data, 'guide'),
-            'meeting_point' => Arr::get($data, 'meeting_point'),
-            'recurrence_enabled' => Arr::get($data, 'recurrence_enabled'),
-            'recurrence_day_hour' => Arr::get($data, 'recurrence_day_hour'),
-        ]);
+            $tour->update([
+                'title' => Arr::get($data, 'title'),
+                'slug' => Str::slug(Arr::get($data, 'title')),
+                'description' => Arr::get($data, 'description'),
+                'featured_image' => $the_feature_image ?? $tour->featured_image,
+                'google_maps_src' => extractSrcFromGmapsIframe(Arr::get($data, 'google_maps_src')) ?? $tour->google_maps_src,
+                'start' => $start,
+                'end' => $end,
+                'price' => Arr::get($data, 'price') ? convert_to_cents(Arr::get($data, 'price')) : 0,
+                'currency' => Arr::get($data, 'currency'),
+                'guide' => Arr::get($data, 'guide'),
+                'meeting_point' => Arr::get($data, 'meeting_point'),
+                'recurrence_enabled' => Arr::get($data, 'recurrence_enabled'),
+                'recurrence_day_hour' => Arr::get($data, 'recurrence_day_hour'),
+            ]);
 
-        $tour->categories()->sync(Arr::get($data, 'category_ids'));
+            $tour->categories()->sync(Arr::get($data, 'category_ids'));
 
-        return $tour;
+            return $tour;
+        });
     }
 
     public function getBySlug(string $slug): Tour

--- a/config/custom.php
+++ b/config/custom.php
@@ -6,6 +6,11 @@ return [
         'width' => 1280,
         'height' => 720,
     ],
+    'events_feature_image' => [
+        'path' => 'events/',
+        'width' => null,
+        'height' => null,
+    ],
     'tours_feature_image' => [
         'path' => 'tours/',
         'width' => 1280,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -14,4 +14,8 @@ if ! grep -q '^APP_KEY=.\+' .env 2>/dev/null; then
   php artisan key:generate --no-interaction
 fi
 
+php artisan storage:link --force 2>/dev/null || true
+mkdir -p storage/app/public/events storage/app/public/places storage/app/public/tours storage/app/public/categories
+chmod -R 775 storage bootstrap/cache 2>/dev/null || true
+
 exec "$@"

--- a/tests/Feature/Dashboard/EventControllerTest.php
+++ b/tests/Feature/Dashboard/EventControllerTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Feature\Dashboard;
 
 use App\Models\Event;
+use App\Services\FeaturedImageStorage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
 use Inertia\Testing\AssertableInertia as Assert;
+use RuntimeException;
 use Tests\TestCase;
 use Tests\Traits\SeedsTestData;
 
@@ -305,7 +307,23 @@ class EventControllerTest extends TestCase
 
         $event = Event::where('slug', 'festival-de-jazz')->first();
         $this->assertNotNull($event->featured_image);
+        $this->assertFileExists(storage_path('app/public/events/'.$event->featured_image));
         $this->assertTrue($event->tags->contains('id', $this->childTag->id));
+    }
+
+    public function test_store_returns_error_when_image_save_fails(): void
+    {
+        $this->mock(FeaturedImageStorage::class, function ($mock) {
+            $mock->shouldReceive('storeFromBase64')->once()->andThrow(new RuntimeException('fail'));
+        });
+
+        $this->actingAs($this->user)
+            ->from('/events/create')
+            ->post('/events', $this->validEventPayload())
+            ->assertRedirect('/events/create')
+            ->assertSessionHasErrors('featured_image');
+
+        $this->assertDatabaseMissing('events', ['slug' => 'festival-de-jazz']);
     }
 
     // ── Edit ─────────────────────────────────────────────────────

--- a/tests/Unit/Services/EventServiceTest.php
+++ b/tests/Unit/Services/EventServiceTest.php
@@ -4,8 +4,10 @@ namespace Tests\Unit\Services;
 
 use App\Models\Event;
 use App\Services\EventService;
+use App\Services\FeaturedImageStorage;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
+use RuntimeException;
 use Tests\TestCase;
 use Tests\Traits\SeedsTestData;
 
@@ -54,6 +56,44 @@ class EventServiceTest extends TestCase
         $this->assertNotNull($filename);
         $this->assertStringStartsWith('event_', $filename);
         $this->assertFileExists(storage_path('app/public/events/'.$filename));
+    }
+
+    public function test_store_featured_image_throws_on_invalid_data(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->eventService->storeFeaturedImage('invalid-image-data');
+    }
+
+    public function test_store_does_not_persist_event_when_image_save_fails(): void
+    {
+        $this->mock(FeaturedImageStorage::class, function ($mock) {
+            $mock->shouldReceive('storeFromBase64')->once()->andThrow(new RuntimeException('fail'));
+        });
+
+        $service = app(EventService::class);
+
+        try {
+            $service->store([
+                'title' => 'Broken Upload Event',
+                'description' => 'Test',
+                'start' => now()->addWeek()->format('Y-m-d'),
+                'end' => now()->addWeeks(2)->format('Y-m-d'),
+                'is_online' => false,
+                'link' => '',
+                'google_maps_src' => 'https://maps.google.com/embed',
+                'address' => 'Test address',
+                'city_id' => $this->city->id,
+                'category_id' => $this->childCategory->id,
+                'featured_image' => $this->base64Pixel,
+                'tag_ids' => [$this->childTag->id],
+            ]);
+            $this->fail('Expected RuntimeException was not thrown.');
+        } catch (RuntimeException) {
+            // expected
+        }
+
+        $this->assertDatabaseMissing('events', ['slug' => 'broken-upload-event']);
     }
 
     public function test_update_preserves_featured_image_when_not_in_payload(): void

--- a/tests/Unit/Services/FeaturedImageStorageTest.php
+++ b/tests/Unit/Services/FeaturedImageStorageTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\FeaturedImageStorage;
+use RuntimeException;
+use Tests\TestCase;
+
+class FeaturedImageStorageTest extends TestCase
+{
+    private FeaturedImageStorage $storage;
+
+    private string $base64Pixel = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->storage = new FeaturedImageStorage;
+    }
+
+    public function test_store_from_base64_returns_null_for_empty_input(): void
+    {
+        $this->assertNull($this->storage->storeFromBase64(null, [
+            'path' => 'events/',
+            'prefix' => 'event_',
+        ]));
+        $this->assertNull($this->storage->storeFromBase64('', [
+            'path' => 'events/',
+            'prefix' => 'event_',
+        ]));
+    }
+
+    public function test_store_from_base64_saves_file_on_public_disk(): void
+    {
+        $filename = $this->storage->storeFromBase64($this->base64Pixel, [
+            'path' => 'events/',
+            'prefix' => 'event_',
+        ]);
+
+        $this->assertNotNull($filename);
+        $this->assertStringStartsWith('event_', $filename);
+        $this->assertFileExists(storage_path('app/public/events/'.$filename));
+
+        @unlink(storage_path('app/public/events/'.$filename));
+    }
+
+    public function test_store_from_base64_throws_on_invalid_data_uri(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->storage->storeFromBase64('not-a-data-uri', [
+            'path' => 'events/',
+            'prefix' => 'event_',
+        ]);
+    }
+
+    public function test_store_from_base64_throws_on_invalid_base64_payload(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->storage->storeFromBase64('data:image/png;base64,%%%', [
+            'path' => 'events/',
+            'prefix' => 'event_',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduz `FeaturedImageStorage` para gravar imagens base64 no disco `public` com validação e verificação pós-gravação.
- Refatora `EventService`, `PlaceService`, `TourService` e `CategoryService` para usar transações DB e não persistir registos quando o upload falha.
- `EventController` devolve erro ao formulário em vez de criar evento sem ficheiro no disco.
- Adiciona `php artisan storage:check-public` (symlink, permissões, registos órfãos) e `storage:link` no `docker-entrypoint.sh`.

## Test plan
- [x] `php artisan test` (190 testes)
- [ ] Em dev: `php artisan storage:link` → criar evento com imagem → ficheiro em `storage/app/public/events/`
- [ ] Em prod (após merge): `sudo -u destinobinacional php artisan storage:link --force`
- [ ] Em prod: `sudo -u destinobinacional php artisan storage:check-public`
- [ ] Criar evento em prod → URL `/storage/events/...` retorna 200
- [ ] Reenviar imagem nos eventos listados como órfãos pelo comando de diagnóstico


Made with [Cursor](https://cursor.com)