### PR TITLE
fix: gravar imagens de eventos como JPEG

### DIFF
--- a/app/Console/Commands/CheckPublicStorage.php
+++ b/app/Console/Commands/CheckPublicStorage.php
@@ -67,6 +67,15 @@ class CheckPublicStorage extends Command
             }
         }
 
+        $eventWebpCount = Event::query()
+            ->whereNotNull('featured_image')
+            ->where('featured_image', 'like', '%.webp')
+            ->count();
+
+        if ($eventWebpCount > 0) {
+            $this->warn("{$eventWebpCount} evento(s) com imagem .webp — em alguns servidores /storage/events/*.webp retorna 403. Reenvie a imagem (passará a .jpg) ou converta no disco.");
+        }
+
         return $ok ? self::SUCCESS : self::FAILURE;
     }
 

--- a/app/Services/EventService.php
+++ b/app/Services/EventService.php
@@ -71,6 +71,8 @@ class EventService
             'prefix' => 'event_',
             'width' => $config['width'],
             'height' => $config['height'],
+            'output_format' => $config['output_format'] ?? null,
+            'output_quality' => $config['output_quality'] ?? 85,
         ]);
     }
 

--- a/app/Services/FeaturedImageStorage.php
+++ b/app/Services/FeaturedImageStorage.php
@@ -13,7 +13,14 @@ class FeaturedImageStorage
     /**
      * Persist a base64 data-URI image on the public disk.
      *
-     * @param  array{path: string, prefix: string, width?: int|null, height?: int|null}  $options
+     * @param  array{
+     *     path: string,
+     *     prefix: string,
+     *     width?: int|null,
+     *     height?: int|null,
+     *     output_format?: string|null,
+     *     output_quality?: int|null
+     * }  $options
      *
      * @throws RuntimeException
      */
@@ -27,8 +34,10 @@ class FeaturedImageStorage
         $prefix = $options['prefix'];
         $width = $options['width'] ?? null;
         $height = $options['height'] ?? null;
+        $outputFormat = isset($options['output_format']) ? strtolower((string) $options['output_format']) : null;
+        $outputQuality = $options['output_quality'] ?? 85;
 
-        $extension = $this->extensionFromDataUri($image);
+        $extension = $outputFormat ?? $this->extensionFromDataUri($image);
         $filename = $prefix.time().'.'.$extension;
         $relativePath = $directory.'/'.$filename;
 
@@ -43,6 +52,8 @@ class FeaturedImageStorage
 
         Storage::disk('public')->makeDirectory($directory);
 
+        $fullPath = storage_path('app/public/'.$relativePath);
+
         try {
             $imageInstance = Image::make($decoded);
 
@@ -50,7 +61,12 @@ class FeaturedImageStorage
                 $imageInstance->resize($width, $height);
             }
 
-            $imageInstance->save(storage_path('app/public/'.$relativePath));
+            if ($outputFormat !== null) {
+                $imageInstance->encode($outputFormat, $outputQuality);
+            }
+
+            $imageInstance->save($fullPath);
+            @chmod($fullPath, 0644);
         } catch (Throwable $e) {
             Log::error('Featured image save failed', [
                 'path' => $relativePath,

--- a/config/custom.php
+++ b/config/custom.php
@@ -10,6 +10,9 @@ return [
         'path' => 'events/',
         'width' => null,
         'height' => null,
+        // Nginx em prod bloqueia .webp em /storage/events/; JPEG é servido normalmente.
+        'output_format' => 'jpg',
+        'output_quality' => 85,
     ],
     'tours_feature_image' => [
         'path' => 'tours/',

--- a/tests/Unit/Services/EventServiceTest.php
+++ b/tests/Unit/Services/EventServiceTest.php
@@ -55,7 +55,10 @@ class EventServiceTest extends TestCase
 
         $this->assertNotNull($filename);
         $this->assertStringStartsWith('event_', $filename);
+        $this->assertStringEndsWith('.jpg', $filename);
         $this->assertFileExists(storage_path('app/public/events/'.$filename));
+
+        @unlink(storage_path('app/public/events/'.$filename));
     }
 
     public function test_store_featured_image_throws_on_invalid_data(): void

--- a/tests/Unit/Services/FeaturedImageStorageTest.php
+++ b/tests/Unit/Services/FeaturedImageStorageTest.php
@@ -63,4 +63,19 @@ class FeaturedImageStorageTest extends TestCase
             'prefix' => 'event_',
         ]);
     }
+
+    public function test_store_from_base64_can_force_output_format(): void
+    {
+        $filename = $this->storage->storeFromBase64($this->base64Pixel, [
+            'path' => 'events/',
+            'prefix' => 'event_',
+            'output_format' => 'jpg',
+        ]);
+
+        $this->assertNotNull($filename);
+        $this->assertStringEndsWith('.jpg', $filename);
+        $this->assertFileExists(storage_path('app/public/events/'.$filename));
+
+        @unlink(storage_path('app/public/events/'.$filename));
+    }
 }


### PR DESCRIPTION
## Summary
- Em produção, `/storage/events/*.webp` retorna 403; `.jpeg`/`.jpg` funciona.
- Força conversão para JPEG no upload de eventos, aplica `chmod 644` e avisa eventos `.webp` no `storage:check-public`.

## Test plan
- [x] `php artisan test --filter=FeaturedImageStorageTest|EventServiceTest`
- [ ] Deploy em prod + reenviar imagem de um evento → URL termina em `.jpg` e retorna HTTP 200


Made with [Cursor](https://cursor.com)